### PR TITLE
Replace FFI by platform channels

### DIFF
--- a/packages/xdg_icons/example/lib/main.dart
+++ b/packages/xdg_icons/example/lib/main.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:xdg_icons/xdg_icons.dart';
 import 'package:yaru/yaru.dart' as yaru;
 
-const kThemes = ['Yaru', 'Adwaita', 'HighContrast'];
+const kThemes = [null, 'Yaru', 'Adwaita', 'HighContrast'];
 const kIcons = [
   'application-x-executable',
   'avatar-default',
@@ -21,9 +21,7 @@ const kIcons = [
   'zoom-in',
 ];
 
-void main() {
-  runApp(const MyApp());
-}
+void main() => runApp(const MyApp());
 
 class MyApp extends StatelessWidget {
   const MyApp({Key? key}) : super(key: key);
@@ -56,9 +54,11 @@ class MyHomePage extends StatelessWidget {
                 for (final theme in kThemes)
                   Padding(
                     padding: const EdgeInsets.all(8.0),
-                    child: Text(theme,
-                        textAlign: TextAlign.center,
-                        style: Theme.of(context).textTheme.headline6),
+                    child: Text(
+                      theme ?? 'Default',
+                      textAlign: TextAlign.center,
+                      style: Theme.of(context).textTheme.headline6,
+                    ),
                   ),
               ],
             ),
@@ -69,10 +69,7 @@ class MyHomePage extends StatelessWidget {
                   for (final theme in kThemes)
                     Padding(
                       padding: const EdgeInsets.all(8.0),
-                      child: XdgIconTheme(
-                        data: XdgIconThemeData(theme: theme),
-                        child: XdgIcon(name: icon, size: 48),
-                      ),
+                      child: XdgIcon(name: icon, size: 48, theme: theme),
                     ),
                 ],
               ),

--- a/packages/xdg_icons/lib/src/data.dart
+++ b/packages/xdg_icons/lib/src/data.dart
@@ -1,0 +1,66 @@
+import 'package:collection/collection.dart';
+
+class XdgIconData {
+  XdgIconData({
+    required this.baseScale,
+    required this.baseSize,
+    required this.fileName,
+    required this.isSymbolic,
+    this.data,
+  });
+
+  final int baseScale;
+  final int baseSize;
+  final String fileName;
+  final bool isSymbolic;
+  final List<int>? data;
+
+  Map<String, dynamic> toJson() {
+    return {
+      'baseScale': baseScale,
+      'baseSize': baseSize,
+      'fileName': fileName,
+      'isSymbolic': isSymbolic,
+      'data': data,
+    };
+  }
+
+  factory XdgIconData.fromJson(Map<String, dynamic> json) {
+    return XdgIconData(
+      baseScale: json['baseScale']?.toInt() ?? 0,
+      baseSize: json['baseSize']?.toInt() ?? 0,
+      fileName: json['fileName'] ?? '',
+      isSymbolic: json['isSymbolic'] ?? false,
+      data: json['data']?.cast<int>(),
+    );
+  }
+
+  @override
+  String toString() {
+    return 'GtkIconInfo(baseScale: $baseScale, baseSize: $baseSize, fileName: $fileName, isSymbolic: $isSymbolic, data: $data)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    final listEquals = const ListEquality().equals;
+    return other is XdgIconData &&
+        other.baseScale == baseScale &&
+        other.baseSize == baseSize &&
+        other.fileName == fileName &&
+        other.isSymbolic == isSymbolic &&
+        listEquals(other.data, data);
+  }
+
+  @override
+  int get hashCode {
+    final listHash = const ListEquality().hash;
+    return Object.hash(
+      baseScale,
+      baseSize,
+      fileName,
+      isSymbolic,
+      listHash(data),
+    );
+  }
+}

--- a/packages/xdg_icons/lib/src/icon.dart
+++ b/packages/xdg_icons/lib/src/icon.dart
@@ -1,49 +1,70 @@
+import 'dart:async';
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:flutter/widgets.dart';
 import 'package:flutter_svg/flutter_svg.dart';
-import 'package:gtk_icon_theme/gtk_icon_theme.dart';
+import 'package:path/path.dart' as path;
+import 'package:xdg_icons/src/platform_interface.dart';
 
+import 'data.dart';
 import 'theme.dart';
 
 class XdgIcon extends StatefulWidget {
   const XdgIcon({
-    Key? key,
+    super.key,
     required this.name,
     required this.size,
     this.scale,
-  }) : super(key: key);
+    this.theme,
+  });
 
   final String name;
   final int size;
   final int? scale;
+  final String? theme;
 
   @override
   State<XdgIcon> createState() => _XdgIconState();
 }
 
 class _XdgIconState extends State<XdgIcon> {
-  GtkIconInfo? _icon;
-  GtkIconTheme? _theme;
+  XdgIconData? _icon;
+  StreamSubscription? _themeChange;
 
-  void _lookupIcon() {
-    final XdgIconThemeData data = XdgIconTheme.of(context);
+  Future<void> _lookupIcon() {
+    final themeData = XdgIconTheme.of(context);
+    return XdgPlatform.instance
+        .lookupIcon(
+          name: widget.name,
+          size: widget.size,
+          scale: widget.scale ?? themeData.scale,
+          theme: widget.theme ?? themeData.theme,
+        )
+        .then(_updateIcon);
+  }
 
-    _theme ??= data.theme?.isNotEmpty == true
-        ? GtkIconTheme.custom(data.theme!)
-        : GtkIconTheme();
+  void _updateIcon(XdgIconData? icon) {
+    if (_icon == icon) return;
+    setState(() => _icon = icon);
+  }
 
-    _icon = _theme!.lookupIcon(
-      widget.name,
-      size: widget.size,
-      scale: widget.scale ?? data.scale,
-    );
+  void _listenThemeChanges() {
+    if (widget.theme == null && XdgIconTheme.of(context).theme == null) {
+      _themeChange ??= XdgPlatform.instance.onDefaultThemeChanged.listen((_) {
+        if (mounted) _lookupIcon();
+      });
+    } else {
+      _themeChange?.cancel();
+      _themeChange = null;
+    }
   }
 
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
     _lookupIcon();
+    _listenThemeChanges();
   }
 
   @override
@@ -51,17 +72,22 @@ class _XdgIconState extends State<XdgIcon> {
     super.didUpdateWidget(oldWidget);
     if (widget.name != oldWidget.name ||
         widget.size != oldWidget.size ||
-        widget.scale != oldWidget.scale) {
+        widget.scale != oldWidget.scale ||
+        widget.theme != oldWidget.theme) {
       _lookupIcon();
+      _listenThemeChanges();
     }
   }
 
   @override
+  void dispose() {
+    super.dispose();
+    _themeChange?.cancel();
+  }
+
+  @override
   Widget build(BuildContext context) {
-    if (_icon == null) {
-      return SizedBox.square(dimension: widget.size.toDouble());
-    }
-    final file = File(_icon!.fileName);
+    final file = File(_icon?.fileName ?? '');
     if (file.existsSync()) {
       final builder = _icon!.isScalable ? SvgPicture.file : Image.file;
       return builder(
@@ -69,13 +95,18 @@ class _XdgIconState extends State<XdgIcon> {
         height: widget.size.toDouble(),
         width: widget.size.toDouble(),
       );
-    } else {
+    } else if (_icon?.data != null) {
       final builder = _icon!.isScalable ? SvgPicture.memory : Image.memory;
       return builder(
-        _icon!.load(),
+        Uint8List.fromList(_icon!.data!),
         height: widget.size.toDouble(),
         width: widget.size.toDouble(),
       );
     }
+    return SizedBox.square(dimension: widget.size.toDouble());
   }
+}
+
+extension XdgIconDataX on XdgIconData {
+  bool get isScalable => path.extension(fileName).toLowerCase() == '.svg';
 }

--- a/packages/xdg_icons/lib/src/method_channel.dart
+++ b/packages/xdg_icons/lib/src/method_channel.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+
+import 'data.dart';
+import 'platform_interface.dart';
+
+/// An implementation of [XdgPlatform] that uses platform channels.
+class XdgMethodChannel extends XdgPlatform {
+  /// The method channel used to interact with the native platform.
+  @visibleForTesting
+  final methodChannel = const MethodChannel('xdg_icons');
+
+  /// The event channel used to receive events from the native platform.
+  @visibleForTesting
+  final eventChannel = const EventChannel('xdg_icons/events');
+
+  @override
+  Future<XdgIconData?> lookupIcon({
+    required String name,
+    required int size,
+    int? scale,
+    String? theme,
+  }) {
+    return methodChannel.invokeMapMethod<String, dynamic>(
+      'lookupIcon',
+      <String, dynamic>{
+        'name': name,
+        'size': size,
+        if (scale != null) 'scale': scale,
+        if (theme != null) 'theme': theme,
+      },
+    ).then((json) => json != null ? XdgIconData.fromJson(json) : null);
+  }
+
+  @override
+  Stream get onDefaultThemeChanged =>
+      _onDefaultThemeChanged ??= eventChannel.receiveBroadcastStream();
+  Stream? _onDefaultThemeChanged;
+}

--- a/packages/xdg_icons/lib/src/platform_interface.dart
+++ b/packages/xdg_icons/lib/src/platform_interface.dart
@@ -1,0 +1,45 @@
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+
+import 'data.dart';
+import 'method_channel.dart';
+
+abstract class XdgPlatform extends PlatformInterface {
+  /// Constructs a XdgPlatform.
+  XdgPlatform() : super(token: _token);
+
+  static final Object _token = Object();
+
+  static XdgPlatform _instance = XdgMethodChannel();
+
+  /// The default instance of [XdgPlatform] to use.
+  ///
+  /// Defaults to [XdgMethodChannel].
+  static XdgPlatform get instance => _instance;
+
+  /// Platform-specific implementations should set this with their own
+  /// platform-specific class that extends [XdgPlatform] when
+  /// they register themselves.
+  static set instance(XdgPlatform instance) {
+    PlatformInterface.verifyToken(instance, _token);
+    _instance = instance;
+  }
+
+  /// Looks up an icon by name and size. Optionally a specific scale or theme
+  /// may be specified.
+  Future<XdgIconData?> lookupIcon({
+    required String name,
+    required int size,
+    int? scale,
+    String? theme,
+  }) {
+    throw UnimplementedError(
+        'XdgPlatform.lookupIcon() has not been implemented.');
+  }
+
+  /// A broadcast stream that emits an event whenever the default icon theme
+  /// changes.
+  Stream get onDefaultThemeChanged {
+    throw UnimplementedError(
+        'XdgPlatform.onThemeChanged has not been implemented.');
+  }
+}

--- a/packages/xdg_icons/lib/src/theme.dart
+++ b/packages/xdg_icons/lib/src/theme.dart
@@ -3,21 +3,23 @@ import 'package:flutter/widgets.dart';
 
 @immutable
 class XdgIconThemeData with Diagnosticable {
-  const XdgIconThemeData({this.theme, this.scale});
+  const XdgIconThemeData({this.theme, this.size, this.scale});
 
   final String? theme;
+  final int? size;
   final int? scale;
 
-  XdgIconThemeData copyWith({String? theme, int? scale}) {
+  XdgIconThemeData copyWith({String? theme, int? size, int? scale}) {
     return XdgIconThemeData(
       theme: theme ?? this.theme,
+      size: size ?? size,
       scale: scale ?? this.scale,
     );
   }
 
   XdgIconThemeData merge(XdgIconThemeData? other) {
     if (other == null) return this;
-    return copyWith(theme: other.theme, scale: other.scale);
+    return copyWith(theme: other.theme, size: other.size, scale: other.scale);
   }
 
   @override
@@ -25,26 +27,24 @@ class XdgIconThemeData with Diagnosticable {
     if (other.runtimeType != runtimeType) return false;
     return other is XdgIconThemeData &&
         theme == other.theme &&
+        size == other.size &&
         scale == other.scale;
   }
 
   @override
-  int get hashCode => Object.hash(theme, scale);
+  int get hashCode => Object.hash(theme, size, scale);
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties.add(StringProperty('theme', theme, defaultValue: null));
+    properties.add(IntProperty('size', size, defaultValue: null));
     properties.add(IntProperty('scale', scale, defaultValue: null));
   }
 }
 
 class XdgIconTheme extends InheritedTheme {
-  const XdgIconTheme({
-    Key? key,
-    required this.data,
-    required Widget child,
-  }) : super(key: key, child: child);
+  const XdgIconTheme({super.key, required this.data, required super.child});
 
   final XdgIconThemeData data;
 

--- a/packages/xdg_icons/linux/CMakeLists.txt
+++ b/packages/xdg_icons/linux/CMakeLists.txt
@@ -1,0 +1,47 @@
+# The Flutter tooling requires that developers have CMake 3.10 or later
+# installed. You should not increase this version, as doing so will cause
+# the plugin to fail to compile for some customers of the plugin.
+cmake_minimum_required(VERSION 3.10)
+
+# Project-level configuration.
+set(PROJECT_NAME "xdg_icons")
+project(${PROJECT_NAME} LANGUAGES CXX)
+
+# This value is used when generating builds using this plugin, so it must
+# not be changed.
+set(PLUGIN_NAME "xdg_icons_plugin")
+
+# Define the plugin library target. Its name must not be changed (see comment
+# on PLUGIN_NAME above).
+#
+# Any new source files that you add to the plugin should be added here.
+add_library(${PLUGIN_NAME} SHARED
+  "xdg_icons_plugin.cc"
+)
+
+# Apply a standard set of build settings that are configured in the
+# application-level CMakeLists.txt. This can be removed for plugins that want
+# full control over build settings.
+apply_standard_settings(${PLUGIN_NAME})
+
+# Symbols are hidden by default to reduce the chance of accidental conflicts
+# between plugins. This should not be removed; any symbols that should be
+# exported should be explicitly exported with the FLUTTER_PLUGIN_EXPORT macro.
+set_target_properties(${PLUGIN_NAME} PROPERTIES
+  CXX_VISIBILITY_PRESET hidden)
+target_compile_definitions(${PLUGIN_NAME} PRIVATE FLUTTER_PLUGIN_IMPL)
+
+# Source include directories and library dependencies. Add any plugin-specific
+# dependencies here.
+target_include_directories(${PLUGIN_NAME} INTERFACE
+  "${CMAKE_CURRENT_SOURCE_DIR}/include")
+target_link_libraries(${PLUGIN_NAME} PRIVATE flutter)
+target_link_libraries(${PLUGIN_NAME} PRIVATE PkgConfig::GTK)
+
+# List of absolute paths to libraries that should be bundled with the plugin.
+# This list could contain prebuilt libraries, or libraries created by an
+# external build triggered from this build file.
+set(xdg_icons_bundled_libraries
+  ""
+  PARENT_SCOPE
+)

--- a/packages/xdg_icons/linux/flutter/generated_plugin_registrant.cc
+++ b/packages/xdg_icons/linux/flutter/generated_plugin_registrant.cc
@@ -1,0 +1,11 @@
+//
+//  Generated file. Do not edit.
+//
+
+// clang-format off
+
+#include "generated_plugin_registrant.h"
+
+
+void fl_register_plugins(FlPluginRegistry* registry) {
+}

--- a/packages/xdg_icons/linux/flutter/generated_plugin_registrant.h
+++ b/packages/xdg_icons/linux/flutter/generated_plugin_registrant.h
@@ -1,0 +1,15 @@
+//
+//  Generated file. Do not edit.
+//
+
+// clang-format off
+
+#ifndef GENERATED_PLUGIN_REGISTRANT_
+#define GENERATED_PLUGIN_REGISTRANT_
+
+#include <flutter_linux/flutter_linux.h>
+
+// Registers Flutter plugins.
+void fl_register_plugins(FlPluginRegistry* registry);
+
+#endif  // GENERATED_PLUGIN_REGISTRANT_

--- a/packages/xdg_icons/linux/flutter/generated_plugins.cmake
+++ b/packages/xdg_icons/linux/flutter/generated_plugins.cmake
@@ -1,0 +1,23 @@
+#
+# Generated file, do not edit.
+#
+
+list(APPEND FLUTTER_PLUGIN_LIST
+)
+
+list(APPEND FLUTTER_FFI_PLUGIN_LIST
+)
+
+set(PLUGIN_BUNDLED_LIBRARIES)
+
+foreach(plugin ${FLUTTER_PLUGIN_LIST})
+  add_subdirectory(flutter/ephemeral/.plugin_symlinks/${plugin}/linux plugins/${plugin})
+  target_link_libraries(${BINARY_NAME} PRIVATE ${plugin}_plugin)
+  list(APPEND PLUGIN_BUNDLED_LIBRARIES $<TARGET_FILE:${plugin}_plugin>)
+  list(APPEND PLUGIN_BUNDLED_LIBRARIES ${${plugin}_bundled_libraries})
+endforeach(plugin)
+
+foreach(ffi_plugin ${FLUTTER_FFI_PLUGIN_LIST})
+  add_subdirectory(flutter/ephemeral/.plugin_symlinks/${ffi_plugin}/linux plugins/${ffi_plugin})
+  list(APPEND PLUGIN_BUNDLED_LIBRARIES ${${ffi_plugin}_bundled_libraries})
+endforeach(ffi_plugin)

--- a/packages/xdg_icons/linux/include/xdg_icons/xdg_icons_plugin.h
+++ b/packages/xdg_icons/linux/include/xdg_icons/xdg_icons_plugin.h
@@ -1,0 +1,26 @@
+#ifndef FLUTTER_PLUGIN_XDG_ICONS_PLUGIN_H_
+#define FLUTTER_PLUGIN_XDG_ICONS_PLUGIN_H_
+
+#include <flutter_linux/flutter_linux.h>
+
+G_BEGIN_DECLS
+
+#ifdef FLUTTER_PLUGIN_IMPL
+#define FLUTTER_PLUGIN_EXPORT __attribute__((visibility("default")))
+#else
+#define FLUTTER_PLUGIN_EXPORT
+#endif
+
+typedef struct _XdgIconsPlugin XdgIconsPlugin;
+typedef struct {
+  GObjectClass parent_class;
+} XdgIconsPluginClass;
+
+FLUTTER_PLUGIN_EXPORT GType xdg_icons_plugin_get_type();
+
+FLUTTER_PLUGIN_EXPORT void xdg_icons_plugin_register_with_registrar(
+    FlPluginRegistrar* registrar);
+
+G_END_DECLS
+
+#endif  // FLUTTER_PLUGIN_XDG_ICONS_PLUGIN_H_

--- a/packages/xdg_icons/linux/xdg_icons_plugin.cc
+++ b/packages/xdg_icons/linux/xdg_icons_plugin.cc
@@ -1,0 +1,155 @@
+#include "include/xdg_icons/xdg_icons_plugin.h"
+
+#include <flutter_linux/flutter_linux.h>
+#include <gtk/gtk.h>
+#include <sys/utsname.h>
+
+#include <cstring>
+
+#define XDG_ICONS_PLUGIN(obj)                                     \
+  (G_TYPE_CHECK_INSTANCE_CAST((obj), xdg_icons_plugin_get_type(), \
+                              XdgIconsPlugin))
+
+struct _XdgIconsPlugin {
+  GObject parent_instance;
+  FlEventChannel* event_channel;
+  gulong theme_changed_id;
+};
+
+G_DEFINE_TYPE(XdgIconsPlugin, xdg_icons_plugin, g_object_get_type())
+
+static FlValue* lookup_icon(FlValue* args) {
+  FlValue* name = fl_value_lookup_string(args, "name");
+  FlValue* size = fl_value_lookup_string(args, "size");
+  FlValue* scale = fl_value_lookup_string(args, "scale");
+  FlValue* theme = fl_value_lookup_string(args, "theme");
+
+  g_autoptr(GtkIconTheme) icon_theme = gtk_icon_theme_get_default();
+  if (theme != nullptr) {
+    icon_theme = gtk_icon_theme_new();
+    gtk_icon_theme_set_custom_theme(icon_theme, fl_value_get_string(theme));
+  } else {
+    g_object_ref(icon_theme);
+  }
+
+  g_autoptr(GtkIconInfo) icon_info =
+      scale != nullptr
+          ? gtk_icon_theme_lookup_icon_for_scale(
+                icon_theme, fl_value_get_string(name), fl_value_get_int(size),
+                fl_value_get_int(scale), GTK_ICON_LOOKUP_USE_BUILTIN)
+          : gtk_icon_theme_lookup_icon(icon_theme, fl_value_get_string(name),
+                                       fl_value_get_int(size),
+                                       GTK_ICON_LOOKUP_USE_BUILTIN);
+
+  if (icon_info == nullptr) {
+    return nullptr;
+  }
+
+  FlValue* result = fl_value_new_map();
+  fl_value_set_string_take(
+      result, "baseScale",
+      fl_value_new_int(gtk_icon_info_get_base_scale(icon_info)));
+  fl_value_set_string_take(
+      result, "baseSize",
+      fl_value_new_int(gtk_icon_info_get_base_size(icon_info)));
+  fl_value_set_string_take(
+      result, "fileName",
+      fl_value_new_string(gtk_icon_info_get_filename(icon_info)));
+  fl_value_set_string_take(
+      result, "isSymbolic",
+      fl_value_new_bool(gtk_icon_info_is_symbolic(icon_info)));
+  g_autoptr(GBytes) bytes =
+      g_resources_lookup_data(gtk_icon_info_get_filename(icon_info),
+                              G_RESOURCE_LOOKUP_FLAGS_NONE, nullptr);
+  if (bytes != nullptr) {
+    gsize size = 0;
+    gconstpointer data = g_bytes_get_data(bytes, &size);
+    fl_value_set_string_take(
+        result, "data",
+        fl_value_new_uint8_list(reinterpret_cast<const uint8_t*>(data), size));
+  }
+  return result;
+}
+
+// Called when a method call is received from Flutter.
+static void xdg_icons_plugin_handle_method_call(XdgIconsPlugin* self,
+                                                FlMethodCall* method_call) {
+  g_autoptr(FlMethodResponse) response = nullptr;
+
+  const gchar* method = fl_method_call_get_name(method_call);
+
+  if (strcmp(method, "lookupIcon") == 0) {
+    FlValue* args = fl_method_call_get_args(method_call);
+    g_autoptr(FlValue) icon = lookup_icon(args);
+    response = FL_METHOD_RESPONSE(fl_method_success_response_new(icon));
+  } else {
+    response = FL_METHOD_RESPONSE(fl_method_not_implemented_response_new());
+  }
+
+  fl_method_call_respond(method_call, response, nullptr);
+}
+
+static void xdg_icons_plugin_dispose(GObject* object) {
+  G_OBJECT_CLASS(xdg_icons_plugin_parent_class)->dispose(object);
+}
+
+static void xdg_icons_plugin_class_init(XdgIconsPluginClass* klass) {
+  G_OBJECT_CLASS(klass)->dispose = xdg_icons_plugin_dispose;
+}
+
+static void xdg_icons_plugin_init(XdgIconsPlugin* self) {}
+
+static void method_call_cb(FlMethodChannel* channel, FlMethodCall* method_call,
+                           gpointer user_data) {
+  XdgIconsPlugin* plugin = XDG_ICONS_PLUGIN(user_data);
+  xdg_icons_plugin_handle_method_call(plugin, method_call);
+}
+
+static void icon_theme_changed_cb(GtkIconTheme* theme, gpointer user_data) {
+  FlEventChannel* channel = FL_EVENT_CHANNEL(user_data);
+  g_autoptr(FlValue) event = fl_value_new_null();
+  fl_event_channel_send(channel, event, nullptr, nullptr);
+}
+
+static FlMethodErrorResponse* listen_events_cb(FlEventChannel* channel,
+                                               FlValue* args,
+                                               gpointer user_data) {
+  XdgIconsPlugin* plugin = XDG_ICONS_PLUGIN(user_data);
+  if (plugin->theme_changed_id == 0) {
+    plugin->theme_changed_id =
+        g_signal_connect(gtk_icon_theme_get_default(), "changed",
+                         G_CALLBACK(icon_theme_changed_cb), channel);
+  }
+  return nullptr;
+}
+
+static FlMethodErrorResponse* cancel_events_cb(FlEventChannel* channel,
+                                               FlValue* args,
+                                               gpointer user_data) {
+  XdgIconsPlugin* plugin = XDG_ICONS_PLUGIN(user_data);
+  if (plugin->theme_changed_id != 0) {
+    g_signal_handler_disconnect(gtk_icon_theme_get_default(),
+                                plugin->theme_changed_id);
+    plugin->theme_changed_id = 0;
+  }
+  return nullptr;
+}
+
+void xdg_icons_plugin_register_with_registrar(FlPluginRegistrar* registrar) {
+  XdgIconsPlugin* plugin =
+      XDG_ICONS_PLUGIN(g_object_new(xdg_icons_plugin_get_type(), nullptr));
+
+  g_autoptr(FlStandardMethodCodec) codec = fl_standard_method_codec_new();
+  FlBinaryMessenger* messenger = fl_plugin_registrar_get_messenger(registrar);
+
+  g_autoptr(FlMethodChannel) method_channel =
+      fl_method_channel_new(messenger, "xdg_icons", FL_METHOD_CODEC(codec));
+  fl_method_channel_set_method_call_handler(
+      method_channel, method_call_cb, g_object_ref(plugin), g_object_unref);
+
+  g_autoptr(FlEventChannel) event_channel = fl_event_channel_new(
+      messenger, "xdg_icons/events", FL_METHOD_CODEC(codec));
+  fl_event_channel_set_stream_handlers(event_channel, listen_events_cb,
+                                       cancel_events_cb, g_object_ref(plugin),
+                                       g_object_unref);
+}

--- a/packages/xdg_icons/pubspec.yaml
+++ b/packages/xdg_icons/pubspec.yaml
@@ -10,15 +10,20 @@ environment:
   flutter: '>=3.0.0'
 
 dependencies:
+  collection: ^1.16.0
   flutter:
     sdk: flutter
   flutter_svg: ^1.1.0
-  gtk_icon_theme:
-    git:
-      url: https://github.com/ubuntu-flutter-community/xdg_icons
-      path: packages/gtk_icon_theme
+  path: ^1.8.0
+  plugin_platform_interface: ^2.1.2
 
 dev_dependencies:
   flutter_lints: ^2.0.0
   flutter_test:
     sdk: flutter
+
+flutter:
+  plugin:
+    platforms:
+      linux:
+        pluginClass: XdgIconsPlugin


### PR DESCRIPTION
It's not possible to connect GtkIconTheme::changed directly to Dart via
FFI because it would attempt to call into Dart outside the main Dart
thread.

- https://github.com/dart-lang/sdk/issues/40529
- https://dart-review.googlesource.com/c/sdk/+/134704